### PR TITLE
Fixed HTTPS Load Balancer Listener Rule

### DIFF
--- a/ecs/service-cluster-alb.yaml
+++ b/ecs/service-cluster-alb.yaml
@@ -155,10 +155,25 @@ Resources:
       Actions:
       - Type: forward
         TargetGroupArn: !Ref LoadBalancerTargetGroup
-      Conditions:
-      - Field: path-pattern
-        Values:
-        - !Sub '/${LoadBalancerPath}/*'
+      Conditions: !If
+      - HasLoadBalancerPath
+      - !If
+        - HasLoadBalancerHostPattern
+        - - Field: host-header
+            Values:
+            - !Ref LoadBalancerHostPattern
+          - Field: path-pattern
+            Values:
+            - !Sub '/${LoadBalancerPath}/*'
+        - - Field: path-pattern
+            Values:
+            - !Sub '/${LoadBalancerPath}/*'
+      - !If
+        - HasLoadBalancerHostPattern
+        - - Field: host-header
+            Values:
+            - !Ref LoadBalancerHostPattern
+        - [] # neither LoadBalancerHostPattern nor LoadBalancerPath specified
       ListenerArn:
         'Fn::ImportValue': !Sub '${ParentClusterStack}-HttpsListener'
       Priority: !Ref LoadBalancerPriority


### PR DESCRIPTION
Now will apply the same Conditions property as the HTTP Listener.
This allows the LoadBalancerHostPattern parameter to be used to
route traffic on the ALB.